### PR TITLE
Add more descriptive account registration results

### DIFF
--- a/html/.config_commonfunctions
+++ b/html/.config_commonfunctions
@@ -600,7 +600,7 @@
 				if ($query){
 					generate_accountverificationfile($username);
 					// $results = "Successfully created user account.<br>An email verification will be sent shortly.<br>";
-					$results = "<center>Your account has been created and is set to disabled. An activation link has been sent to the email address you entered.<br>Please following the activation link sent in the email to enable your account. Activation emails can take up to 10 minutes to receive so please be patient.<br>If your activation email does not arrive please contact a moderator and ask to activate your account or use our contact us link on our main site.</center>";
+					$results = "<center>Your account has been created and is set to disabled. An activation link has been sent to the email address you entered.<br>Please following the activation link sent in the email to enable your account. Activation emails can take up to 10 minutes to receive so please be patient.<br>If your activation email does not arrive please contact a moderator and ask to activate your account or use our contact us link on our main site.<br><br>If you do not see a link in your email, please view source (or show original) of the email.<br>Chances are your email client/provider is incorrectly identifying the email as a phishing email and hiding the link for security reasons.<br><b>GMAIL DOES THIS!</b><br>To view source using gmail select the following:<br><br><img src='showoriginal.jpg'></img></center>";
 				} else {
 					$results = "failed, " . mysql_error();
 				}


### PR DESCRIPTION
Add details about what users should do after the account registration page is displayed in the event there email provider blocks the links sent for there account verification emails.