### PR TITLE
Prevent double punctuation

### DIFF
--- a/html/.config_commonfunctions
+++ b/html/.config_commonfunctions
@@ -1,7 +1,7 @@
 <?php
     $configfile = ".config";
     $saved_user_id_change_file = "user_changed.txt";
-    date_default_timezone_set('.get_config_value($configfile,"timezone").'); // Matches up with MySQL
+    date_default_timezone_set('.get_config_value($configfile, "timezone").'); // Matches up with MySQL
 
     function already_changed_name($configfile, $id_to_find)
     {
@@ -13,7 +13,7 @@
         
         if (in_array($id_to_find, $all_ids))
             return true;
-        
+
         return false;
     }
     
@@ -62,10 +62,6 @@
             {
                 return "Error: You cannot start your new username with 'Player_'";
             }
-            /*else if (preg_match("/^[a-zA-Z0-9_\\.-]+$/", $old)) // Old Name Is Fine Already
-            {
-                return "Error: You may only change your username if your name was invalid";
-            }*/
             else if ($info_q[1] > 0) // Moderator
             {
                 return "Error: Moderators may not change their username without approval";
@@ -77,6 +73,14 @@
             else if (already_changed_name($saved_user_id_change_file, $info_q[2])) // Already Changed Username Once
             {
                 return "Error: You may only change your username once";
+            }
+            else if (preg_match("/[.,_-]{2,}/", $new)) // New Name Has Two Punctuation Marks In A Row
+            {
+                return "Error: You cannot have two punctuation marks in a row";
+            }
+            else if (!is_numeric($new[0]) && !ctype_alpha($new[0])) // First Character Is Not A Letter Or Number
+            {
+                return "Error: Your username must start with a letter or number";
             }
             
             $username_is_taken = mysql_num_rows(mysql_query("SELECT `id` FROM `$user_table` WHERE name = '$new' AND name != '$old' LIMIT 0,1"));
@@ -101,8 +105,7 @@
         else
         {
             return "Error: Invalid Username/Password combination";
-        }    
-
+        }
     }
     
     function calculate_string($mathString) {

--- a/html/createaccount.php
+++ b/html/createaccount.php
@@ -3,44 +3,46 @@
 <head>
 <title>Servatrice Administrator</title>
 </head>
-	<body>
-		<?php
-			require '.config_commonfunctions';
-        	global $configfile;
-		?>
-		<table align="center" border="1" cellpadding="5">
-			<tr>
-				<td align="center"><a href="loginpage.php">Account Log-in</a></td>
-				<td align="center"><a href="index.php">Home</a></td>
-			</tr>
-			<tr>
-				<td colspan="2">
-					<?php
-						if ($_SERVER['REQUEST_METHOD'] == 'POST')
-						{
-							$username_to_reg = $_POST["nametoregister"];
-							$pass_to_reg = $_POST["passwordtouse"];
-							$email_to_reg = $_POST["emailtouse"];
+    <body>
+        <?php
+            require '.config_commonfunctions';
+            global $configfile;
+        ?>
+        <table align="center" border="1" cellpadding="5">
+            <tr>
+                <td align="center"><a href="loginpage.php">Account Log-in</a></td>
+                <td align="center"><a href="index.php">Home</a></td>
+            </tr>
+            <tr>
+                <td colspan="2">
+                    <?php
+                        if ($_POST)
+                        {
+                            $username_to_reg = mysql_real_escape_string($_POST["nametoregister"]);
+                            $pass_to_reg = mysql_real_escape_string($_POST["passwordtouse"]);
+                            $email_to_reg = mysql_real_escape_string($_POST["emailtouse"]);
 
-							$username_has_valid_chars = preg_match('/^[\w-]+$/', $username_to_reg);
-							$username_has_bad_name = preg_match('/^Player_\d+$/', $username_to_reg);
+                            $username_has_valid_chars = preg_match('/^[\w-]+$/', $username_to_reg); // A-Z, a-z, 0-9, _, ., -
+                            $username_has_bad_name = preg_match('/^Player_\d+$/', $username_to_reg); // Player_*
+                            $username_has_double_punc = preg_match("/[.,_-]{2,}/", $username_to_reg); // Has no double punc (i.e. cant be 'steve._milk')
+                            $username_starts_with_let_or_num = is_numeric($username_to_reg[0]) || ctype_alpha($username_to_reg[0]); // Starts w/ letter or num
 
-							if (empty($username_to_reg) || empty($pass_to_reg) || empty($email_to_reg))
-							{
-								echo "All fields are required";
-							}
-							else if ($username_has_valid_chars && $username_has_bad_name === 0) // Only A-Z, a-z, 0-9, -, _ AND does not start with "Player_"
-							{
-								echo add_user($username_to_reg, $pass_to_reg, $email_to_reg);
-							}
-							else
-							{
-								echo "You may only use <b>A-Z, a-z, 0-9, _,</b> and <b>-</b> in your username. In addition, your username can't start with \"Player_\"<br/>\n";
-							}
-						}
-					?>
-				</td>
-			</tr>
-		</table>
-	</body>
+                            if (empty($username_to_reg) || empty($pass_to_reg) || empty($email_to_reg))
+                            {
+                                echo "All fields are required";
+                            }
+                            else if ($username_has_valid_chars && $username_has_bad_name === 0 && !$username_has_double_punc && $username_starts_with_let_or_num)
+                            {
+                                echo add_user($username_to_reg, $pass_to_reg, $email_to_reg);
+                            }
+                            else
+                            {
+                                echo "You may only use <b>A-Z, a-z, 0-9, _,</b> and <b>-</b> in your username. In addition, your username can't start with \"Player_\"<br/>\n";
+                            }
+                        }
+                    ?>
+                </td>
+            </tr>
+        </table>
+    </body>
 </html>


### PR DESCRIPTION
@poixen doesn't want users to be able to reg a name like "bing.......o" so this prevents the use of two dots/periods, along with any punctuation mark, in a row anywhere in a username.

This also prevents people from starting a username with something other than a letter (A-Z, a-z) or a number (0-9)

Valid:
+ **Bing.o_man3**
+ **Chinese_food_**
+ **8Radish-b_tree.**

Invalid:
+ **The_cheesey_one-_-**
    + The -_ is invalid as it's two punc in a row
+ **Red_cross..30**
    + The .. is invalid as it's two punc in a row
+ **_I.Love.Bacon.**
    + The _ is invalid because you can only start with a letter / number


